### PR TITLE
Fix app version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
           name: cross compile
           command: |
             go get .
-            tag=$(semantics --output-tag --dry-run)
+            tag=$(semantics --output-tag --dry-run | sed -e "s/^v//")
             if [ "$tag" ]; then
               echo "found release version $tag"
               gox -ldflags "-X github.com/signavio/aws-mfa-login/cmd.Version=$tag" -os="linux darwin windows" -arch="amd64" -output="dist/aws-mfa-login_{{.OS}}_{{.Arch}}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ jobs:
               echo "no new release detected using git SHA1 ${CIRCLE_BRANCH}-${CIRCLE_SHA1} as version"
               gox -ldflags "-X github.com/signavio/aws-mfa-login/cmd.Version=${CIRCLE_BRANCH}-${CIRCLE_SHA1}" -os="linux darwin windows" -arch="amd64" -output="dist/aws-mfa-login_{{.OS}}_{{.Arch}}"
             fi
+            ./dist/aws-mfa-login_linux_amd64 --version
             cd dist/ && gzip *
       - persist_to_workspace:
           root: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,14 @@ jobs:
           name: cross compile
           command: |
             go get .
-            gox -os="linux darwin windows" -arch="amd64" -output="dist/aws-mfa-login_{{.OS}}_{{.Arch}}"
+            tag=$(semantics --output-tag --dry-run)
+            if [ "$tag" ]; then
+              echo "found release version $tag"
+              gox -ldflags "-X github.com/signavio/aws-mfa-login/cmd.Version=$tag" -os="linux darwin windows" -arch="amd64" -output="dist/aws-mfa-login_{{.OS}}_{{.Arch}}"
+            else
+              echo "no new release detected using git SHA1 ${CIRCLE_BRANCH}-${CIRCLE_SHA1} as version"
+              gox -ldflags "-X github.com/signavio/aws-mfa-login/cmd.Version=${CIRCLE_BRANCH}-${CIRCLE_SHA1}" -os="linux darwin windows" -arch="amd64" -output="dist/aws-mfa-login_{{.OS}}_{{.Arch}}"
+            fi
             cd dist/ && gzip *
       - persist_to_workspace:
           root: .

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @karlderkaefer @signavio/devops

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,15 +16,13 @@ var (
 	conf *action.Clusters
 )
 
-var (
-	VERSION = "0.1.1"
-)
+var Version string
 
 var rootCmd = &cobra.Command{
 	Use:     "aws-mfa-login",
 	Short:   "aws login with mfa",
 	Long:    "CLI tool to update your temporary AWS credentials ",
-	Version: VERSION,
+	Version: Version,
 	Run: func(cmd *cobra.Command, args []string) {
 		action.PrintConfigWithoutClusterConfig()
 		action.UpdateSessionCredentials()
@@ -36,6 +34,9 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.aws-mfa.yaml)")
 	rootCmd.PersistentFlags().StringVarP(&Name, "source", "s", "", "source profile where mfa is activated")
 	rootCmd.PersistentFlags().StringVarP(&Destination, "destination", "d", "", "destination profile for temporary aws credentials")
+	if Version == "" {
+		rootCmd.Version = "dev"
+	}
 	rootCmd.InitDefaultVersionFlag()
 	err := viper.BindPFlag("source", rootCmd.PersistentFlags().Lookup("source"))
 	if err != nil {


### PR DESCRIPTION
It was a bit confusing. When increasing the release version. it also had to be done in cmd/root.go. Now we will automatically overwrite the version during cross-compile with the next release version. 