### PR TITLE
fix: support arm64 architecture for linux and mac

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
               export VERSION="${APP_VERSION}"
             fi
             echo "got version ${VERSION}"
-            gox -ldflags "-X github.com/signavio/aws-mfa-login/cmd.Version=${VERSION}" -os="linux darwin windows" -arch="amd64" -output="dist/${CIRCLE_PROJECT_REPONAME}_{{.OS}}_{{.Arch}}"
+            gox -ldflags "-X github.com/signavio/aws-mfa-login/cmd.Version=${VERSION}" -os="linux darwin windows" -arch="amd64 arm64" -output="dist/${CIRCLE_PROJECT_REPONAME}_{{.OS}}_{{.Arch}}"
             ./dist/${CIRCLE_PROJECT_REPONAME}_linux_amd64 --version
             cd dist/ && gzip *
       - persist_to_workspace:


### PR DESCRIPTION
```
gox -ldflags "-X github.com/signavio/aws-mfa-login/cmd.Version=${VERSION}" -os="linux darwin windows" -arch="amd64 arm64" -output="dist/aws-mfa-login_{{.OS}}_{{.Arch}}"
Number of parallel builds: 15

-->    darwin/amd64: github.com/signavio/aws-mfa-login
-->    darwin/arm64: github.com/signavio/aws-mfa-login
-->     linux/amd64: github.com/signavio/aws-mfa-login
-->   windows/amd64: github.com/signavio/aws-mfa-login
-->     linux/arm64: github.com/signavio/aws-mfa-login
```

closes #46

