### PR TITLE
Adapt installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For this, go must be installed on your system.
 
 Install executable with golang
 ```bash
-go get github.com/signavio/aws-mfa-login
+go install github.com/signavio/aws-mfa-login@latest
 ```
 Make sure your go path is part of your PATH environment variable: 
 ```


### PR DESCRIPTION
'go get' is no longer supported outside a module.
To build and install a command, use 'go install' with a version, like 'go install example.com/cmd@latest'
For more information, see https://golang.org/doc/go-get-install-deprecation