### PR TITLE
Revert "fix(CORE-130): update authentication.k8s.io beta->v1"

### DIFF
--- a/action/kubeconfig.go
+++ b/action/kubeconfig.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
-	"os"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
@@ -18,6 +15,8 @@ import (
 	"github.com/spf13/viper"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"log"
+	"os"
 )
 
 type KubeConfigUpdater struct {
@@ -115,7 +114,7 @@ func (c *ClusterConfig) writeKubeconfig(clusterInfo *eks.DescribeClusterOutput) 
 				Value: c.Alias,
 			},
 		},
-		APIVersion: "client.authentication.k8s.io/v1",
+		APIVersion: "client.authentication.k8s.io/v1beta1",
 	}
 
 	contextConfig := clientcmdapi.NewContext()


### PR DESCRIPTION
Reverts signavio/aws-mfa-login#84
According to https://github.com/aws/aws-cli/pull/6940 this can only be change to `v1` if EKS =>1.22.
Let's have it after all clusters are updated